### PR TITLE
Implement interfaces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.composer/cache
@@ -67,7 +67,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.composer/cache
@@ -107,7 +107,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.composer/cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,27 +8,9 @@ $finder = (new PhpCsFixer\Finder())
 return (new PhpCsFixer\Config())
     ->setRules([
         '@PhpCsFixer' => true,
-        '@PSR1' => true,
-        '@PSR2' => true,
+        '@PER-CS' => true,
         '@Symfony' => true,
-        'array_syntax' => ['syntax' => 'short'],
         'php_unit_method_casing' => ['case' => 'snake_case'],
-
-        // @PSR12
-        'blank_line_after_opening_tag' => true,
-        'braces' => ['allow_single_line_closure' => true],
-        'compact_nullable_typehint' => true,
-        'concat_space' => ['spacing' => 'one'],
-        'declare_equal_normalize' => ['space' => 'none'],
-        'function_typehint_space' => true,
-        'new_with_braces' => true,
-        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
-        'no_empty_statement' => true,
-        'no_leading_import_slash' => true,
-        'no_leading_namespace_whitespace' => true,
-        'no_whitespace_in_blank_line' => true,
-        'return_type_declaration' => ['space_before' => 'none'],
-        'single_trait_insert_per_statement' => true,
     ])
     ->setFinder($finder)
 ;

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 $finder = (new PhpCsFixer\Finder())
     ->in(__DIR__)
     ->exclude(['var', 'vendor'])
 ;
 
 return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
     ->setRules([
         '@PhpCsFixer' => true,
         '@PER-CS' => true,
         '@Symfony' => true,
+        'declare_strict_types' => true,
         'php_unit_method_casing' => ['case' => 'snake_case'],
     ])
     ->setFinder($finder)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Make classes final
 
+### ✨ New features
+
+* Implement `ChecksumProvider`, `PublicUrlGenerator` and `TemporaryUrlGenerator`
+
 ## v0.6.0 (February 15, 2025)
 
 ### 💥 Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.7.0 (unreleased)
+
+### 💥 Breaking changes
+
+* Make classes final
+
 ## v0.6.0 (February 15, 2025)
 
 ### 💥 Breaking changes

--- a/src/Command/ListMessagesCommand.php
+++ b/src/Command/ListMessagesCommand.php
@@ -154,7 +154,7 @@ final class ListMessagesCommand extends Command
                 'adapter',
                 'a',
                 InputOption::VALUE_REQUIRED,
-                'Name of the failover adapter for which to list messages ' .
+                'Name of the failover adapter for which to list messages '.
                 sprintf(
                     ' (one of <comment>"%s"</comment>)',
                     join('"</comment>, <comment>"', $adapters)

--- a/src/Command/ListMessagesCommand.php
+++ b/src/Command/ListMessagesCommand.php
@@ -21,7 +21,7 @@ use Webf\FlysystemFailoverBundle\MessageRepository\FindByCriteria;
 use Webf\FlysystemFailoverBundle\MessageRepository\MessageRepositoryInterface;
 use Webf\FlysystemFailoverBundle\Serializer\Normalizer\FindResultsNormalizer;
 
-class ListMessagesCommand extends Command
+final class ListMessagesCommand extends Command
 {
     public function __construct(
         private FailoverAdaptersLocatorInterface $failoverAdaptersLocator,
@@ -31,6 +31,7 @@ class ListMessagesCommand extends Command
         parent::__construct();
     }
 
+    #[\Override]
     protected function execute(
         InputInterface $input,
         OutputInterface $output,
@@ -136,6 +137,7 @@ class ListMessagesCommand extends Command
         return 0;
     }
 
+    #[\Override]
     protected function configure(): void
     {
         $this

--- a/src/Command/ProcessMessagesCommand.php
+++ b/src/Command/ProcessMessagesCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Webf\FlysystemFailoverBundle\MessageHandler\MessageHandlerLocator;
 use Webf\FlysystemFailoverBundle\MessageRepository\MessageRepositoryInterface;
 
-class ProcessMessagesCommand extends Command
+final class ProcessMessagesCommand extends Command
 {
     public function __construct(
         private MessageHandlerLocator $messageHandlerLocator,
@@ -21,6 +21,7 @@ class ProcessMessagesCommand extends Command
         parent::__construct();
     }
 
+    #[\Override]
     protected function execute(
         InputInterface $input,
         OutputInterface $output,
@@ -65,6 +66,7 @@ class ProcessMessagesCommand extends Command
         $io->success('Message successfully processed');
     }
 
+    #[\Override]
     protected function configure(): void
     {
         $this

--- a/src/Command/SyncCommand.php
+++ b/src/Command/SyncCommand.php
@@ -49,7 +49,7 @@ final class SyncCommand extends Command
 
         $io = new SymfonyStyle($input, $output);
 
-        $stats = new class() {
+        $stats = new class {
             /** @var array<int, int> */
             private array $nbReplicatedMap = [];
 
@@ -144,7 +144,7 @@ final class SyncCommand extends Command
                 $message = $event->getMessage();
 
                 $io->write(sprintf(
-                    'Dispatching message to replicate file ' .
+                    'Dispatching message to replicate file '.
                     '<comment>%s</comment> from storage %s to %s...',
                     $message->getPath(),
                     $message->getInnerSourceAdapter(),
@@ -166,7 +166,7 @@ final class SyncCommand extends Command
             DeleteFileMessagePreDispatch::class,
             function (DeleteFileMessagePreDispatch $event) use ($io, $stats) {
                 $io->write(sprintf(
-                    'Dispatching message to delete file ' .
+                    'Dispatching message to delete file '.
                     '<comment>%s</comment> from storage %s...',
                     $event->getMessage()->getPath(),
                     $event->getMessage()->getInnerDestinationAdapter(),
@@ -226,7 +226,7 @@ final class SyncCommand extends Command
         $this
             ->setName('webf:flysystem-failover:sync')
             ->setDescription(
-                'Synchronize storages to replicate all files present in the ' .
+                'Synchronize storages to replicate all files present in the '.
                 'first one to the others'
             )
         ;
@@ -239,8 +239,8 @@ final class SyncCommand extends Command
             $this->addArgument(
                 'adapter',
                 InputArgument::REQUIRED,
-                'Name of the failover adapter for which to scan the ' .
-                'underlaying storages' .
+                'Name of the failover adapter for which to scan the '.
+                'underlaying storages'.
                 sprintf(
                     ' (one of <comment>"%s"</comment>)',
                     join('"</comment>, <comment>"', $adapters)
@@ -252,7 +252,7 @@ final class SyncCommand extends Command
             'extra-files',
             mode: InputOption::VALUE_OPTIONAL,
             description: sprintf(
-                'How to handle extra files in secondary storages. One of ' .
+                'How to handle extra files in secondary storages. One of '.
                 '<comment>"%s"</comment>.',
                 join('"</comment>, <comment>"', [
                     SyncService::EXTRA_FILES_IGNORE,
@@ -266,7 +266,7 @@ final class SyncCommand extends Command
         $this->addOption(
             'ignore-modification-dates',
             mode: InputOption::VALUE_NONE,
-            description: 'Do not replicate files already present in ' .
+            description: 'Do not replicate files already present in '.
                 'secondary storages, even if the modification date is older.'
         );
     }

--- a/src/Command/SyncCommand.php
+++ b/src/Command/SyncCommand.php
@@ -22,7 +22,7 @@ use Webf\FlysystemFailoverBundle\Event\SyncService\SearchingFilesToReplicateStar
 use Webf\FlysystemFailoverBundle\Flysystem\FailoverAdaptersLocatorInterface;
 use Webf\FlysystemFailoverBundle\Service\SyncService;
 
-class SyncCommand extends Command
+final class SyncCommand extends Command
 {
     public function __construct(
         private EventDispatcherInterface $eventDispatcher,
@@ -32,6 +32,7 @@ class SyncCommand extends Command
         parent::__construct();
     }
 
+    #[\Override]
     protected function execute(
         InputInterface $input,
         OutputInterface $output,
@@ -219,6 +220,7 @@ class SyncCommand extends Command
         return 0;
     }
 
+    #[\Override]
     protected function configure(): void
     {
         $this

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -9,8 +9,9 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
+    #[\Override]
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('webf_flysystem_failover');

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -80,8 +80,8 @@ final class Configuration implements ConfigurationInterface
 
             ->integerNode('time_shift')
             ->info(
-                'Time shift in seconds of the inner adapter compared to ' .
-                'others (e.g. if the underlying storage use a different ' .
+                'Time shift in seconds of the inner adapter compared to '.
+                'others (e.g. if the underlying storage use a different '.
                 'timezone or if has an incorrect server time).'
             )
             ->end()

--- a/src/DependencyInjection/WebfFlysystemFailoverExtension.php
+++ b/src/DependencyInjection/WebfFlysystemFailoverExtension.php
@@ -48,36 +48,36 @@ final class WebfFlysystemFailoverExtension extends Extension
 {
     private const PREFIX = 'webf_flysystem_failover';
 
-    public const FAILOVER_ADAPTER_SERVICE_ID_PREFIX = self::PREFIX . '.adapter';
+    public const FAILOVER_ADAPTER_SERVICE_ID_PREFIX = self::PREFIX.'.adapter';
     public const FAILOVER_ADAPTERS_LOCATOR_SERVICE_ID =
-        self::PREFIX . '.adapters_locator';
+        self::PREFIX.'.adapters_locator';
 
     public const MESSAGE_REPOSITORY_SERVICE_ID =
-        self::PREFIX . '.message_repository';
+        self::PREFIX.'.message_repository';
 
     public const MESSAGE_HANDLER_LOCATOR_SERVICE_ID =
-        self::PREFIX . '.message_handler_locator';
+        self::PREFIX.'.message_handler_locator';
     public const DELETE_DIRECTORY_MESSAGE_HANDLER_SERVICE_ID =
-        self::PREFIX . '.message_handler.delete_directory';
+        self::PREFIX.'.message_handler.delete_directory';
     public const DELETE_FILE_MESSAGE_HANDLER_SERVICE_ID =
-        self::PREFIX . '.message_handler.delete_file';
+        self::PREFIX.'.message_handler.delete_file';
     public const REPLICATE_FILE_MESSAGE_HANDLER_SERVICE_ID =
-        self::PREFIX . '.message_handler.replicate_file';
-    public const MESSAGE_HANDLER_TAG_NAME = self::PREFIX . '.message_handler';
+        self::PREFIX.'.message_handler.replicate_file';
+    public const MESSAGE_HANDLER_TAG_NAME = self::PREFIX.'.message_handler';
 
     public const FIND_RESULTS_NORMALIZER_SERVICE_ID =
-        self::PREFIX . '.normalizer.find_results';
+        self::PREFIX.'.normalizer.find_results';
 
-    public const SYNC_SERVICE_ID = self::PREFIX . '.service.sync';
+    public const SYNC_SERVICE_ID = self::PREFIX.'.service.sync';
 
     public const DOCTRINE_SCHEMA_LISTENER_SERVICE_ID =
-        self::PREFIX . '.listener.doctrine_schema';
+        self::PREFIX.'.listener.doctrine_schema';
 
     public const LIST_MESSAGES_COMMAND_SERVICE_ID =
-        self::PREFIX . '.command.list_messages';
+        self::PREFIX.'.command.list_messages';
     public const PROCESS_MESSAGE_COMMAND_SERVICE_ID =
-        self::PREFIX . '.command.process_message';
-    public const SCAN_COMMAND_SERVICE_ID = self::PREFIX . '.command.scan';
+        self::PREFIX.'.command.process_message';
+    public const SCAN_COMMAND_SERVICE_ID = self::PREFIX.'.command.scan';
 
     #[\Override]
     public function load(array $configs, ContainerBuilder $container): void
@@ -140,7 +140,7 @@ final class WebfFlysystemFailoverExtension extends Extension
     ): void {
         $references = [];
         foreach ($config['adapters'] as $name => $failoverAdapter) {
-            $serviceId = self::FAILOVER_ADAPTER_SERVICE_ID_PREFIX . '.' . $name;
+            $serviceId = self::FAILOVER_ADAPTER_SERVICE_ID_PREFIX.'.'.$name;
 
             $container->setDefinition(
                 $serviceId,

--- a/src/DependencyInjection/WebfFlysystemFailoverExtension.php
+++ b/src/DependencyInjection/WebfFlysystemFailoverExtension.php
@@ -44,7 +44,7 @@ use Webf\FlysystemFailoverBundle\Service\SyncService;
  *     message_repository_dsn: string
  * }
  */
-class WebfFlysystemFailoverExtension extends Extension
+final class WebfFlysystemFailoverExtension extends Extension
 {
     private const PREFIX = 'webf_flysystem_failover';
 
@@ -79,6 +79,7 @@ class WebfFlysystemFailoverExtension extends Extension
         self::PREFIX . '.command.process_message';
     public const SCAN_COMMAND_SERVICE_ID = self::PREFIX . '.command.scan';
 
+    #[\Override]
     public function load(array $configs, ContainerBuilder $container): void
     {
         /** @var _Config $config */

--- a/src/Event/SyncService/DeleteFileMessageDispatched.php
+++ b/src/Event/SyncService/DeleteFileMessageDispatched.php
@@ -6,7 +6,7 @@ namespace Webf\FlysystemFailoverBundle\Event\SyncService;
 
 use Webf\FlysystemFailoverBundle\Message\MessageInterface;
 
-class DeleteFileMessageDispatched
+final class DeleteFileMessageDispatched
 {
     public function __construct(private MessageInterface $message)
     {

--- a/src/Event/SyncService/DeleteFileMessagePreDispatch.php
+++ b/src/Event/SyncService/DeleteFileMessagePreDispatch.php
@@ -6,7 +6,7 @@ namespace Webf\FlysystemFailoverBundle\Event\SyncService;
 
 use Webf\FlysystemFailoverBundle\Message\DeleteFile;
 
-class DeleteFileMessagePreDispatch
+final class DeleteFileMessagePreDispatch
 {
     public function __construct(private DeleteFile $message)
     {

--- a/src/Event/SyncService/ListingContentFailed.php
+++ b/src/Event/SyncService/ListingContentFailed.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Webf\FlysystemFailoverBundle\Event\SyncService;
 
-class ListingContentFailed extends AbstractListingContentEvent
+final class ListingContentFailed extends AbstractListingContentEvent
 {
 }

--- a/src/Event/SyncService/ListingContentStarted.php
+++ b/src/Event/SyncService/ListingContentStarted.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Webf\FlysystemFailoverBundle\Event\SyncService;
 
-class ListingContentStarted extends AbstractListingContentEvent
+final class ListingContentStarted extends AbstractListingContentEvent
 {
 }

--- a/src/Event/SyncService/ListingContentSucceeded.php
+++ b/src/Event/SyncService/ListingContentSucceeded.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Webf\FlysystemFailoverBundle\Event\SyncService;
 
-class ListingContentSucceeded extends AbstractListingContentEvent
+final class ListingContentSucceeded extends AbstractListingContentEvent
 {
     public function __construct(
         string $failoverAdapter,

--- a/src/Event/SyncService/ReplicateFileMessageDispatched.php
+++ b/src/Event/SyncService/ReplicateFileMessageDispatched.php
@@ -6,7 +6,7 @@ namespace Webf\FlysystemFailoverBundle\Event\SyncService;
 
 use Webf\FlysystemFailoverBundle\Message\MessageInterface;
 
-class ReplicateFileMessageDispatched
+final class ReplicateFileMessageDispatched
 {
     public function __construct(private MessageInterface $message)
     {

--- a/src/Event/SyncService/ReplicateFileMessagePreDispatch.php
+++ b/src/Event/SyncService/ReplicateFileMessagePreDispatch.php
@@ -6,7 +6,7 @@ namespace Webf\FlysystemFailoverBundle\Event\SyncService;
 
 use Webf\FlysystemFailoverBundle\Message\ReplicateFile;
 
-class ReplicateFileMessagePreDispatch
+final class ReplicateFileMessagePreDispatch
 {
     public function __construct(private ReplicateFile $message)
     {

--- a/src/Event/SyncService/SearchingFilesToReplicateStarted.php
+++ b/src/Event/SyncService/SearchingFilesToReplicateStarted.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Webf\FlysystemFailoverBundle\Event\SyncService;
 
-class SearchingFilesToReplicateStarted
+final class SearchingFilesToReplicateStarted
 {
     public function __construct(
         private string $failoverAdapter,

--- a/src/EventListener/DoctrineSchemaListener.php
+++ b/src/EventListener/DoctrineSchemaListener.php
@@ -14,7 +14,7 @@ namespace Webf\FlysystemFailoverBundle\EventListener;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use Webf\FlysystemFailoverBundle\MessageRepository\DoctrineMessageRepository;
 
-class DoctrineSchemaListener
+final class DoctrineSchemaListener
 {
     public function __construct(private DoctrineMessageRepository $repository)
     {

--- a/src/EventListener/DoctrineSchemaListener.php
+++ b/src/EventListener/DoctrineSchemaListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/src/EventListener/DoctrineSchemaListener.php
+++ b/src/EventListener/DoctrineSchemaListener.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Symfony package.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Webf\FlysystemFailoverBundle\EventListener;
 
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;

--- a/src/Exception/FailoverAdapterNotFoundException.php
+++ b/src/Exception/FailoverAdapterNotFoundException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Webf\FlysystemFailoverBundle\Exception;
 
-class FailoverAdapterNotFoundException extends OutOfBoundsException
+final class FailoverAdapterNotFoundException extends OutOfBoundsException
 {
     public static function withName(string $name): FailoverAdapterNotFoundException
     {

--- a/src/Exception/InnerAdapterNotFoundException.php
+++ b/src/Exception/InnerAdapterNotFoundException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Webf\FlysystemFailoverBundle\Exception;
 
-class InnerAdapterNotFoundException extends OutOfBoundsException
+final class InnerAdapterNotFoundException extends OutOfBoundsException
 {
     public static function in(
         string $failoverAdapterName,

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Webf\FlysystemFailoverBundle\Exception;
 
-class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+final class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Exception/UnsupportedOperationException.php
+++ b/src/Exception/UnsupportedOperationException.php
@@ -6,6 +6,6 @@ namespace Webf\FlysystemFailoverBundle\Exception;
 
 use League\Flysystem\FilesystemException;
 
-class UnsupportedOperationException extends LogicException implements FilesystemException
+final class UnsupportedOperationException extends LogicException implements FilesystemException
 {
 }

--- a/src/Flysystem/FailoverAdapter.php
+++ b/src/Flysystem/FailoverAdapter.php
@@ -26,7 +26,7 @@ use Webf\FlysystemFailoverBundle\MessageRepository\MessageRepositoryInterface;
  *
  * @template-implements CompositeFilesystemAdapter<InnerAdapter<T>>
  */
-class FailoverAdapter implements CompositeFilesystemAdapter
+final class FailoverAdapter implements CompositeFilesystemAdapter
 {
     /**
      * @param iterable<int, InnerAdapter<T>> $adapters
@@ -38,6 +38,7 @@ class FailoverAdapter implements CompositeFilesystemAdapter
     ) {
     }
 
+    #[\Override]
     public function fileExists(string $path): bool
     {
         foreach ($this->adapters as $adapter) {
@@ -51,6 +52,7 @@ class FailoverAdapter implements CompositeFilesystemAdapter
         throw UnableToCheckFileExistence::forLocation($path);
     }
 
+    #[\Override]
     public function directoryExists(string $path): bool
     {
         foreach ($this->adapters as $adapter) {
@@ -64,6 +66,7 @@ class FailoverAdapter implements CompositeFilesystemAdapter
         throw UnableToCheckDirectoryExistence::forLocation($path);
     }
 
+    #[\Override]
     public function write(string $path, string $contents, Config $config): void
     {
         $writtenAdapter = null;
@@ -98,6 +101,7 @@ class FailoverAdapter implements CompositeFilesystemAdapter
         throw UnableToWriteFile::atLocation($path);
     }
 
+    #[\Override]
     public function writeStream(string $path, $contents, Config $config): void
     {
         $writtenAdapter = null;
@@ -132,6 +136,7 @@ class FailoverAdapter implements CompositeFilesystemAdapter
         throw UnableToWriteFile::atLocation($path);
     }
 
+    #[\Override]
     public function read(string $path): string
     {
         foreach ($this->adapters as $adapter) {
@@ -145,6 +150,7 @@ class FailoverAdapter implements CompositeFilesystemAdapter
         throw UnableToReadFile::fromLocation($path);
     }
 
+    #[\Override]
     public function readStream(string $path)
     {
         foreach ($this->adapters as $adapter) {
@@ -158,6 +164,7 @@ class FailoverAdapter implements CompositeFilesystemAdapter
         throw UnableToReadFile::fromLocation($path);
     }
 
+    #[\Override]
     public function delete(string $path): void
     {
         foreach ($this->adapters as $name => $adapter) {
@@ -172,6 +179,7 @@ class FailoverAdapter implements CompositeFilesystemAdapter
         }
     }
 
+    #[\Override]
     public function deleteDirectory(string $path): void
     {
         foreach ($this->adapters as $name => $adapter) {
@@ -186,16 +194,19 @@ class FailoverAdapter implements CompositeFilesystemAdapter
         }
     }
 
+    #[\Override]
     public function createDirectory(string $path, Config $config): void
     {
         throw new UnsupportedOperationException(sprintf('Method "createDirectory" is not supported with "%s".', self::class));
     }
 
+    #[\Override]
     public function setVisibility(string $path, string $visibility): void
     {
         throw new UnsupportedOperationException(sprintf('Method "setVisibility" is not supported with "%s".', self::class));
     }
 
+    #[\Override]
     public function visibility(string $path): FileAttributes
     {
         foreach ($this->adapters as $adapter) {
@@ -209,6 +220,7 @@ class FailoverAdapter implements CompositeFilesystemAdapter
         throw UnableToRetrieveMetadata::visibility($path);
     }
 
+    #[\Override]
     public function mimeType(string $path): FileAttributes
     {
         foreach ($this->adapters as $adapter) {
@@ -222,6 +234,7 @@ class FailoverAdapter implements CompositeFilesystemAdapter
         throw UnableToRetrieveMetadata::mimeType($path);
     }
 
+    #[\Override]
     public function lastModified(string $path): FileAttributes
     {
         foreach ($this->adapters as $adapter) {
@@ -235,6 +248,7 @@ class FailoverAdapter implements CompositeFilesystemAdapter
         throw UnableToRetrieveMetadata::lastModified($path);
     }
 
+    #[\Override]
     public function fileSize(string $path): FileAttributes
     {
         foreach ($this->adapters as $adapter) {
@@ -248,16 +262,19 @@ class FailoverAdapter implements CompositeFilesystemAdapter
         throw UnableToRetrieveMetadata::fileSize($path);
     }
 
+    #[\Override]
     public function listContents(string $path, bool $deep): iterable
     {
         throw new UnsupportedOperationException(sprintf('Method "listContents" is not supported with "%s".', self::class));
     }
 
+    #[\Override]
     public function move(string $source, string $destination, Config $config): void
     {
         throw new UnsupportedOperationException(sprintf('Method "move" is not supported with "%s".', self::class));
     }
 
+    #[\Override]
     public function copy(string $source, string $destination, Config $config): void
     {
         throw new UnsupportedOperationException(sprintf('Method "copy" is not supported with "%s".', self::class));
@@ -285,6 +302,7 @@ class FailoverAdapter implements CompositeFilesystemAdapter
     /**
      * @return iterable<int, InnerAdapter<T>>
      */
+    #[\Override]
     public function getInnerAdapters(): iterable
     {
         return $this->adapters;

--- a/src/Flysystem/FailoverAdaptersLocator.php
+++ b/src/Flysystem/FailoverAdaptersLocator.php
@@ -14,7 +14,7 @@ use Webf\FlysystemFailoverBundle\Exception\FailoverAdapterNotFoundException;
  * @template-implements FailoverAdaptersLocatorInterface<T>
  * @template-implements IteratorAggregate<string, FailoverAdapter<T>>
  */
-class FailoverAdaptersLocator implements FailoverAdaptersLocatorInterface, \IteratorAggregate
+final class FailoverAdaptersLocator implements FailoverAdaptersLocatorInterface, \IteratorAggregate
 {
     private bool $iterableConsumed = false;
 
@@ -33,6 +33,7 @@ class FailoverAdaptersLocator implements FailoverAdaptersLocatorInterface, \Iter
     /**
      * @return FailoverAdapter<T>
      */
+    #[\Override]
     public function get(string $name): FailoverAdapter
     {
         if (key_exists($name, $this->failoverAdapters)) {
@@ -57,6 +58,7 @@ class FailoverAdaptersLocator implements FailoverAdaptersLocatorInterface, \Iter
     /**
      * @return \ArrayIterator<string, FailoverAdapter<T>>
      */
+    #[\Override]
     public function getIterator(): \ArrayIterator
     {
         if (!$this->iterableConsumed) {

--- a/src/Flysystem/InnerAdapter.php
+++ b/src/Flysystem/InnerAdapter.php
@@ -18,7 +18,7 @@ use Webf\Flysystem\Composite\CompositeFilesystemAdapter;
  *
  * @template-implements CompositeFilesystemAdapter<T>
  */
-class InnerAdapter implements CompositeFilesystemAdapter
+final class InnerAdapter implements CompositeFilesystemAdapter
 {
     /**
      * @param T        $adapter
@@ -35,91 +35,109 @@ class InnerAdapter implements CompositeFilesystemAdapter
         return $this->options['time_shift'] ?? 0;
     }
 
+    #[\Override]
     public function fileExists(string $path): bool
     {
         return $this->adapter->fileExists($path);
     }
 
+    #[\Override]
     public function directoryExists(string $path): bool
     {
         return $this->adapter->directoryExists($path);
     }
 
+    #[\Override]
     public function write(string $path, string $contents, Config $config): void
     {
         $this->adapter->write($path, $contents, $config);
     }
 
+    #[\Override]
     public function writeStream(string $path, $contents, Config $config): void
     {
         $this->adapter->writeStream($path, $contents, $config);
     }
 
+    #[\Override]
     public function read(string $path): string
     {
         return $this->adapter->read($path);
     }
 
+    #[\Override]
     public function readStream(string $path)
     {
         return $this->adapter->readStream($path);
     }
 
+    #[\Override]
     public function delete(string $path): void
     {
         $this->adapter->delete($path);
     }
 
+    #[\Override]
     public function deleteDirectory(string $path): void
     {
         $this->adapter->deleteDirectory($path);
     }
 
+    #[\Override]
     public function createDirectory(string $path, Config $config): void
     {
         $this->adapter->createDirectory($path, $config);
     }
 
+    #[\Override]
     public function setVisibility(string $path, string $visibility): void
     {
         $this->adapter->setVisibility($path, $visibility);
     }
 
+    #[\Override]
     public function visibility(string $path): FileAttributes
     {
         return $this->adapter->visibility($path);
     }
 
+    #[\Override]
     public function mimeType(string $path): FileAttributes
     {
         return $this->adapter->mimeType($path);
     }
 
+    #[\Override]
     public function lastModified(string $path): FileAttributes
     {
         return $this->adapter->lastModified($path);
     }
 
+    #[\Override]
     public function fileSize(string $path): FileAttributes
     {
         return $this->adapter->fileSize($path);
     }
 
+    #[\Override]
     public function listContents(string $path, bool $deep): iterable
     {
         return $this->adapter->listContents($path, $deep);
     }
 
+    #[\Override]
     public function move(string $source, string $destination, Config $config): void
     {
         $this->adapter->move($source, $destination, $config);
     }
 
+    #[\Override]
     public function copy(string $source, string $destination, Config $config): void
     {
         $this->adapter->copy($source, $destination, $config);
     }
 
+    #[\Override]
     public function getInnerAdapters(): iterable
     {
         return [$this->adapter];

--- a/src/Flysystem/InnerAdapter.php
+++ b/src/Flysystem/InnerAdapter.php
@@ -137,6 +137,14 @@ final class InnerAdapter implements CompositeFilesystemAdapter
         $this->adapter->copy($source, $destination, $config);
     }
 
+    /**
+     * @return T
+     */
+    public function getInnerAdapter(): FilesystemAdapter
+    {
+        return $this->adapter;
+    }
+
     #[\Override]
     public function getInnerAdapters(): iterable
     {

--- a/src/Message/DeleteDirectory.php
+++ b/src/Message/DeleteDirectory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Webf\FlysystemFailoverBundle\Message;
 
-class DeleteDirectory implements MessageInterface
+final class DeleteDirectory implements MessageInterface
 {
     public function __construct(
         private string $failoverAdapter,
@@ -14,31 +14,37 @@ class DeleteDirectory implements MessageInterface
     ) {
     }
 
+    #[\Override]
     public function getFailoverAdapter(): string
     {
         return $this->failoverAdapter;
     }
 
+    #[\Override]
     public function getPath(): string
     {
         return $this->path;
     }
 
+    #[\Override]
     public function getInnerSourceAdapter(): ?int
     {
         return null;
     }
 
+    #[\Override]
     public function getInnerDestinationAdapter(): int
     {
         return $this->innerAdapter;
     }
 
+    #[\Override]
     public function getRetryCount(): int
     {
         return $this->retryCount;
     }
 
+    #[\Override]
     public function __toString()
     {
         return sprintf(

--- a/src/Message/DeleteFile.php
+++ b/src/Message/DeleteFile.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Webf\FlysystemFailoverBundle\Message;
 
-class DeleteFile implements MessageInterface
+final class DeleteFile implements MessageInterface
 {
     public function __construct(
         private string $failoverAdapter,
@@ -14,31 +14,37 @@ class DeleteFile implements MessageInterface
     ) {
     }
 
+    #[\Override]
     public function getFailoverAdapter(): string
     {
         return $this->failoverAdapter;
     }
 
+    #[\Override]
     public function getPath(): string
     {
         return $this->path;
     }
 
+    #[\Override]
     public function getInnerSourceAdapter(): ?int
     {
         return null;
     }
 
+    #[\Override]
     public function getInnerDestinationAdapter(): int
     {
         return $this->innerAdapter;
     }
 
+    #[\Override]
     public function getRetryCount(): int
     {
         return $this->retryCount;
     }
 
+    #[\Override]
     public function __toString()
     {
         return sprintf(

--- a/src/Message/ReplicateFile.php
+++ b/src/Message/ReplicateFile.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Webf\FlysystemFailoverBundle\Message;
 
-class ReplicateFile implements MessageInterface
+final class ReplicateFile implements MessageInterface
 {
     public function __construct(
         private string $failoverAdapter,
@@ -15,31 +15,37 @@ class ReplicateFile implements MessageInterface
     ) {
     }
 
+    #[\Override]
     public function getFailoverAdapter(): string
     {
         return $this->failoverAdapter;
     }
 
+    #[\Override]
     public function getPath(): string
     {
         return $this->path;
     }
 
+    #[\Override]
     public function getInnerSourceAdapter(): int
     {
         return $this->innerSourceAdapter;
     }
 
+    #[\Override]
     public function getInnerDestinationAdapter(): int
     {
         return $this->innerDestinationAdapter;
     }
 
+    #[\Override]
     public function getRetryCount(): int
     {
         return $this->retryCount;
     }
 
+    #[\Override]
     public function __toString()
     {
         return sprintf(

--- a/src/MessageHandler/DeleteDirectoryHandler.php
+++ b/src/MessageHandler/DeleteDirectoryHandler.php
@@ -9,7 +9,7 @@ use Webf\FlysystemFailoverBundle\Flysystem\FailoverAdaptersLocatorInterface;
 use Webf\FlysystemFailoverBundle\Message\DeleteDirectory;
 use Webf\FlysystemFailoverBundle\MessageRepository\MessageRepositoryInterface;
 
-class DeleteDirectoryHandler implements MessageHandlerInterface
+final class DeleteDirectoryHandler implements MessageHandlerInterface
 {
     public function __construct(
         private FailoverAdaptersLocatorInterface $adaptersLocator,

--- a/src/MessageHandler/DeleteFileHandler.php
+++ b/src/MessageHandler/DeleteFileHandler.php
@@ -9,7 +9,7 @@ use Webf\FlysystemFailoverBundle\Flysystem\FailoverAdaptersLocatorInterface;
 use Webf\FlysystemFailoverBundle\Message\DeleteFile;
 use Webf\FlysystemFailoverBundle\MessageRepository\MessageRepositoryInterface;
 
-class DeleteFileHandler implements MessageHandlerInterface
+final class DeleteFileHandler implements MessageHandlerInterface
 {
     public function __construct(
         private FailoverAdaptersLocatorInterface $adaptersLocator,

--- a/src/MessageHandler/MessageHandlerLocator.php
+++ b/src/MessageHandler/MessageHandlerLocator.php
@@ -7,7 +7,7 @@ namespace Webf\FlysystemFailoverBundle\MessageHandler;
 use Webf\FlysystemFailoverBundle\Exception\InvalidArgumentException;
 use Webf\FlysystemFailoverBundle\Message\MessageInterface;
 
-class MessageHandlerLocator
+final class MessageHandlerLocator
 {
     /**
      * @var array<class-string, callable(MessageInterface)|MessageHandlerInterface>

--- a/src/MessageHandler/ReplicateFileHandler.php
+++ b/src/MessageHandler/ReplicateFileHandler.php
@@ -14,7 +14,7 @@ use Webf\FlysystemFailoverBundle\Flysystem\FailoverAdaptersLocatorInterface;
 use Webf\FlysystemFailoverBundle\Message\ReplicateFile;
 use Webf\FlysystemFailoverBundle\MessageRepository\MessageRepositoryInterface;
 
-class ReplicateFileHandler implements MessageHandlerInterface
+final class ReplicateFileHandler implements MessageHandlerInterface
 {
     /**
      * @template T of FilesystemAdapter

--- a/src/MessageRepository/FindByCriteria.php
+++ b/src/MessageRepository/FindByCriteria.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Webf\FlysystemFailoverBundle\MessageRepository;
 
-class FindByCriteria
+final class FindByCriteria
 {
     public const DEFAULT_LIMIT = 30;
     public const DEFAULT_PAGE = 1;

--- a/src/MessageRepository/FindResults.php
+++ b/src/MessageRepository/FindResults.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Webf\FlysystemFailoverBundle\MessageRepository;
 
-class FindResults
+final class FindResults
 {
     /**
      * @param iterable<int, MessageWithMetadata> $items

--- a/src/MessageRepository/InMemoryMessageRepository.php
+++ b/src/MessageRepository/InMemoryMessageRepository.php
@@ -6,18 +6,20 @@ namespace Webf\FlysystemFailoverBundle\MessageRepository;
 
 use Webf\FlysystemFailoverBundle\Message\MessageInterface;
 
-class InMemoryMessageRepository implements MessageRepositoryInterface
+final class InMemoryMessageRepository implements MessageRepositoryInterface
 {
     /**
      * @var array<MessageInterface>
      */
     private array $messages = [];
 
+    #[\Override]
     public function push(MessageInterface $message): void
     {
         $this->messages[] = $message;
     }
 
+    #[\Override]
     public function pop(): ?MessageInterface
     {
         return array_shift($this->messages);
@@ -31,6 +33,7 @@ class InMemoryMessageRepository implements MessageRepositoryInterface
         return $messages;
     }
 
+    #[\Override]
     public function findBy(FindByCriteria $criteria): FindResults
     {
         $now = new \DateTimeImmutable();

--- a/src/MessageRepository/InMemoryMessageRepository.php
+++ b/src/MessageRepository/InMemoryMessageRepository.php
@@ -36,29 +36,42 @@ final class InMemoryMessageRepository implements MessageRepositoryInterface
     #[\Override]
     public function findBy(FindByCriteria $criteria): FindResults
     {
-        $now = new \DateTimeImmutable();
-
-        $items = [];
-        $i = 0;
-        foreach ($this->messages as $message) {
-            if (null !== ($failoverAdapter = $criteria->getFailoverAdapter())) {
-                if ($message->getFailoverAdapter() !== $failoverAdapter) {
-                    continue;
-                }
-            }
-
-            $items[] = new MessageWithMetadata($message, $now, $now);
-
-            if (++$i > $criteria->getLimit()) {
-                break;
-            }
-        }
-
         return new FindResults(
             $criteria->getLimit(),
             count($this->messages),
             $criteria->getPage(),
-            $items
+            $this->iterateBy($criteria),
         );
+    }
+
+    /**
+     * @return iterable<int, MessageWithMetadata>
+     */
+    private function iterateBy(FindByCriteria $criteria): iterable
+    {
+        $now = new \DateTimeImmutable();
+
+        $i = 0; // index of the message in the complete array
+        $j = 0; // number of eligible messages (without considering page and limit)
+        $k = 0; // number of returned messages
+
+        while (isset($this->messages[$i]) && $k < $criteria->getLimit()) {
+            if (null !== $criteria->getFailoverAdapter() && $criteria->getFailoverAdapter() !== $this->messages[$i]->getFailoverAdapter()) {
+                ++$i;
+                continue;
+            }
+
+            if ($j < ($criteria->getPage() - 1) * $criteria->getLimit()) {
+                ++$i;
+                ++$j;
+                continue;
+            }
+
+            yield new MessageWithMetadata($this->messages[$i], $now, $now);
+
+            ++$i;
+            ++$j;
+            ++$k;
+        }
     }
 }

--- a/src/MessageRepository/MessageWithMetadata.php
+++ b/src/MessageRepository/MessageWithMetadata.php
@@ -6,7 +6,7 @@ namespace Webf\FlysystemFailoverBundle\MessageRepository;
 
 use Webf\FlysystemFailoverBundle\Message\MessageInterface;
 
-class MessageWithMetadata
+final class MessageWithMetadata
 {
     public function __construct(
         private MessageInterface $message,

--- a/src/Serializer/Normalizer/FindResultsNormalizer.php
+++ b/src/Serializer/Normalizer/FindResultsNormalizer.php
@@ -12,10 +12,11 @@ use Webf\FlysystemFailoverBundle\Message\ReplicateFile;
 use Webf\FlysystemFailoverBundle\MessageRepository\FindResults;
 use Webf\FlysystemFailoverBundle\MessageRepository\MessageWithMetadata;
 
-class FindResultsNormalizer implements NormalizerInterface
+final class FindResultsNormalizer implements NormalizerInterface
 {
     public const SUPPORTED_FORMATS = ['csv', 'json', 'xml'];
 
+    #[\Override]
     public function normalize($object, $format = null, array $context = []): array
     {
         if (!$object instanceof FindResults) {
@@ -34,6 +35,7 @@ class FindResultsNormalizer implements NormalizerInterface
         };
     }
 
+    #[\Override]
     public function supportsNormalization($data, $format = null, array $context = []): bool
     {
         return $data instanceof FindResults && in_array($format, self::SUPPORTED_FORMATS);

--- a/src/Service/SyncService.php
+++ b/src/Service/SyncService.php
@@ -23,7 +23,7 @@ use Webf\FlysystemFailoverBundle\Message\DeleteFile;
 use Webf\FlysystemFailoverBundle\Message\ReplicateFile;
 use Webf\FlysystemFailoverBundle\MessageRepository\MessageRepositoryInterface;
 
-class SyncService
+final class SyncService
 {
     public const EXTRA_FILES_COPY = 'copy';
     public const EXTRA_FILES_DELETE = 'delete';

--- a/src/WebfFlysystemFailoverBundle.php
+++ b/src/WebfFlysystemFailoverBundle.php
@@ -6,6 +6,6 @@ namespace Webf\FlysystemFailoverBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class WebfFlysystemFailoverBundle extends Bundle
+final class WebfFlysystemFailoverBundle extends Bundle
 {
 }

--- a/tests/EventListener/DoctrineSchemaListenerTest.php
+++ b/tests/EventListener/DoctrineSchemaListenerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Webf\FlysystemFailoverBundle\EventListener;
 
 use Doctrine\DBAL\DriverManager;

--- a/tests/EventListener/DoctrineSchemaListenerTest.php
+++ b/tests/EventListener/DoctrineSchemaListenerTest.php
@@ -26,7 +26,7 @@ use Webf\FlysystemFailoverBundle\MessageRepository\DoctrineMessageRepository;
  * @covers \Webf\FlysystemFailoverBundle\EventListener\DoctrineSchemaListener
  * @covers \Webf\FlysystemFailoverBundle\MessageRepository\DoctrineMessageRepository
  */
-class DoctrineSchemaListenerTest extends TestCase
+final class DoctrineSchemaListenerTest extends TestCase
 {
     public function test_schema_is_creatable_on_all_platforms(): void
     {

--- a/tests/Flysystem/FailoverAdapterTest.php
+++ b/tests/Flysystem/FailoverAdapterTest.php
@@ -27,7 +27,7 @@ final class FailoverAdapterTest extends TestCase
 {
     public function test_checksum_forwards_parameters_to_inner_adapter(): void
     {
-        $adapter = new class() extends InMemoryFilesystemAdapter implements ChecksumProvider {
+        $adapter = new class extends InMemoryFilesystemAdapter implements ChecksumProvider {
             #[\Override]
             public function checksum(string $path, Config $config): string
             {
@@ -55,7 +55,7 @@ final class FailoverAdapterTest extends TestCase
     {
         $adapter0 = new InMemoryFilesystemAdapter();
 
-        $adapter1 = new class() extends InMemoryFilesystemAdapter implements ChecksumProvider {
+        $adapter1 = new class extends InMemoryFilesystemAdapter implements ChecksumProvider {
             #[\Override]
             public function checksum(string $path, Config $config): string
             {
@@ -63,7 +63,7 @@ final class FailoverAdapterTest extends TestCase
             }
         };
 
-        $adapter2 = new class() extends InMemoryFilesystemAdapter implements ChecksumProvider {
+        $adapter2 = new class extends InMemoryFilesystemAdapter implements ChecksumProvider {
             #[\Override]
             public function checksum(string $path, Config $config): string
             {
@@ -71,7 +71,7 @@ final class FailoverAdapterTest extends TestCase
             }
         };
 
-        $adapter3 = new class() extends InMemoryFilesystemAdapter implements ChecksumProvider {
+        $adapter3 = new class extends InMemoryFilesystemAdapter implements ChecksumProvider {
             #[\Override]
             public function checksum(string $path, Config $config): string
             {
@@ -79,7 +79,7 @@ final class FailoverAdapterTest extends TestCase
             }
         };
 
-        $adapter4 = new class() extends InMemoryFilesystemAdapter implements ChecksumProvider {
+        $adapter4 = new class extends InMemoryFilesystemAdapter implements ChecksumProvider {
             #[\Override]
             public function checksum(string $path, Config $config): string
             {
@@ -122,7 +122,7 @@ final class FailoverAdapterTest extends TestCase
 
     public function test_checksum_throw_exception_when_no_inner_adapter_succeed_to_provide_checksum(): void
     {
-        $adapter0 = new class() extends InMemoryFilesystemAdapter implements ChecksumProvider {
+        $adapter0 = new class extends InMemoryFilesystemAdapter implements ChecksumProvider {
             #[\Override]
             public function checksum(string $path, Config $config): string
             {
@@ -130,7 +130,7 @@ final class FailoverAdapterTest extends TestCase
             }
         };
 
-        $adapter1 = new class() extends InMemoryFilesystemAdapter implements ChecksumProvider {
+        $adapter1 = new class extends InMemoryFilesystemAdapter implements ChecksumProvider {
             #[\Override]
             public function checksum(string $path, Config $config): string
             {
@@ -153,7 +153,7 @@ final class FailoverAdapterTest extends TestCase
 
     public function test_public_url_forwards_parameters_to_inner_adapter(): void
     {
-        $adapter = new class() extends InMemoryFilesystemAdapter implements PublicUrlGenerator {
+        $adapter = new class extends InMemoryFilesystemAdapter implements PublicUrlGenerator {
             #[\Override]
             public function publicUrl(string $path, Config $config): string
             {
@@ -181,7 +181,7 @@ final class FailoverAdapterTest extends TestCase
     {
         $adapter0 = new InMemoryFilesystemAdapter();
 
-        $adapter1 = new class() extends InMemoryFilesystemAdapter implements PublicUrlGenerator {
+        $adapter1 = new class extends InMemoryFilesystemAdapter implements PublicUrlGenerator {
             #[\Override]
             public function publicUrl(string $path, Config $config): string
             {
@@ -189,7 +189,7 @@ final class FailoverAdapterTest extends TestCase
             }
         };
 
-        $adapter2 = new class() extends InMemoryFilesystemAdapter implements PublicUrlGenerator {
+        $adapter2 = new class extends InMemoryFilesystemAdapter implements PublicUrlGenerator {
             #[\Override]
             public function publicUrl(string $path, Config $config): string
             {
@@ -197,7 +197,7 @@ final class FailoverAdapterTest extends TestCase
             }
         };
 
-        $adapter3 = new class() extends InMemoryFilesystemAdapter implements PublicUrlGenerator {
+        $adapter3 = new class extends InMemoryFilesystemAdapter implements PublicUrlGenerator {
             #[\Override]
             public function publicUrl(string $path, Config $config): string
             {
@@ -240,7 +240,7 @@ final class FailoverAdapterTest extends TestCase
 
     public function test_public_url_throw_exception_when_no_inner_adapter_succeed_to_provide_public_url(): void
     {
-        $adapter = new class() extends InMemoryFilesystemAdapter implements PublicUrlGenerator {
+        $adapter = new class extends InMemoryFilesystemAdapter implements PublicUrlGenerator {
             #[\Override]
             public function publicUrl(string $path, Config $config): string
             {
@@ -263,7 +263,7 @@ final class FailoverAdapterTest extends TestCase
 
     public function test_temporary_url_forwards_parameters_to_inner_adapter(): void
     {
-        $adapter = new class() extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
+        $adapter = new class extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
             #[\Override]
             public function temporaryUrl(string $path, \DateTimeInterface $expiresAt, Config $config): string
             {
@@ -293,7 +293,7 @@ final class FailoverAdapterTest extends TestCase
     {
         $adapter0 = new InMemoryFilesystemAdapter();
 
-        $adapter1 = new class() extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
+        $adapter1 = new class extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
             #[\Override]
             public function temporaryUrl(string $path, \DateTimeInterface $expiresAt, Config $config): string
             {
@@ -301,7 +301,7 @@ final class FailoverAdapterTest extends TestCase
             }
         };
 
-        $adapter2 = new class() extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
+        $adapter2 = new class extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
             #[\Override]
             public function temporaryUrl(string $path, \DateTimeInterface $expiresAt, Config $config): string
             {
@@ -309,7 +309,7 @@ final class FailoverAdapterTest extends TestCase
             }
         };
 
-        $adapter3 = new class() extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
+        $adapter3 = new class extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
             #[\Override]
             public function temporaryUrl(string $path, \DateTimeInterface $expiresAt, Config $config): string
             {
@@ -352,7 +352,7 @@ final class FailoverAdapterTest extends TestCase
 
     public function test_temporary_url_throw_exception_when_no_inner_adapter_succeed_to_provide_temporary_url(): void
     {
-        $adapter = new class() extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
+        $adapter = new class extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
             #[\Override]
             public function temporaryUrl(string $path, \DateTimeInterface $expiresAt, Config $config): string
             {

--- a/tests/Flysystem/FailoverAdapterTest.php
+++ b/tests/Flysystem/FailoverAdapterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Webf\FlysystemFailoverBundle\Flysystem;
 
 use League\Flysystem\ChecksumAlgoIsNotSupported;

--- a/tests/Flysystem/FailoverAdapterTest.php
+++ b/tests/Flysystem/FailoverAdapterTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Webf\FlysystemFailoverBundle\Flysystem;
+
+use League\Flysystem\Config;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use League\Flysystem\UnableToGenerateTemporaryUrl;
+use League\Flysystem\UrlGeneration\TemporaryUrlGenerator;
+use PHPUnit\Framework\TestCase;
+use Webf\FlysystemFailoverBundle\Flysystem\FailoverAdapter;
+use Webf\FlysystemFailoverBundle\Flysystem\InnerAdapter;
+use Webf\FlysystemFailoverBundle\MessageRepository\InMemoryMessageRepository;
+
+/**
+ * @internal
+ *
+ * @covers \Webf\FlysystemFailoverBundle\Flysystem\FailoverAdapter
+ */
+final class FailoverAdapterTest extends TestCase
+{
+    public function test_temporary_url_forwards_parameters_to_inner_adapter(): void
+    {
+        $adapter = new class() extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
+            #[\Override]
+            public function temporaryUrl(string $path, \DateTimeInterface $expiresAt, Config $config): string
+            {
+                $config = $config->toArray();
+
+                return sprintf(
+                    '%s?expires=%s&%s',
+                    $path,
+                    $expiresAt->getTimestamp(),
+                    join('&', array_map(fn ($k, $v) => "{$k}={$v}", array_keys($config), $config)),
+                );
+            }
+        };
+
+        $filesystem = new Filesystem(
+            new FailoverAdapter('default', $this->toInner([$adapter]), new InMemoryMessageRepository())
+        );
+
+        $expiresAt = new \DateTime('+1 day');
+        $this->assertEquals(
+            "file.txt?expires={$expiresAt->getTimestamp()}&foo=bar&baz=qux",
+            $filesystem->temporaryUrl('file.txt', $expiresAt, ['foo' => 'bar', 'baz' => 'qux']),
+        );
+    }
+
+    public function test_generating_temporary_url_returns_first_successful_temporary_url(): void
+    {
+        $adapter0 = new InMemoryFilesystemAdapter();
+
+        $adapter1 = new class() extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
+            #[\Override]
+            public function temporaryUrl(string $path, \DateTimeInterface $expiresAt, Config $config): string
+            {
+                throw new UnableToGenerateTemporaryUrl('this adapter fails to generate temporary URL.', $path);
+            }
+        };
+
+        $adapter2 = new class() extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
+            #[\Override]
+            public function temporaryUrl(string $path, \DateTimeInterface $expiresAt, Config $config): string
+            {
+                return 'temporary_url_of_adapter_1';
+            }
+        };
+
+        $adapter3 = new class() extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
+            #[\Override]
+            public function temporaryUrl(string $path, \DateTimeInterface $expiresAt, Config $config): string
+            {
+                return 'temporary_url_of_adapter_2';
+            }
+        };
+
+        $filesystem = new Filesystem(
+            new FailoverAdapter(
+                'default',
+                $this->toInner([$adapter0, $adapter1, $adapter2, $adapter3]),
+                new InMemoryMessageRepository()
+            )
+        );
+
+        $this->assertEquals(
+            'temporary_url_of_adapter_1',
+            $filesystem->temporaryUrl('file.txt', new \DateTime('+1 day'))
+        );
+    }
+
+    public function test_temporary_url_throw_exception_when_no_inner_adapter_can_generate_temporary_url(): void
+    {
+        $adapter0 = new InMemoryFilesystemAdapter();
+        $adapter1 = new InMemoryFilesystemAdapter();
+        $adapter2 = new InMemoryFilesystemAdapter();
+
+        $filesystem = new Filesystem(
+            new FailoverAdapter(
+                'default',
+                $this->toInner([$adapter0, $adapter1, $adapter2]),
+                new InMemoryMessageRepository()
+            )
+        );
+
+        $this->expectException(UnableToGenerateTemporaryUrl::class);
+
+        $filesystem->temporaryUrl('file.txt', new \DateTime('+1 day'));
+    }
+
+    public function test_temporary_url_throw_exception_when_no_inner_adapter_succeed_to_provide_temporary_url(): void
+    {
+        $adapter = new class() extends InMemoryFilesystemAdapter implements TemporaryUrlGenerator {
+            #[\Override]
+            public function temporaryUrl(string $path, \DateTimeInterface $expiresAt, Config $config): string
+            {
+                throw new UnableToGenerateTemporaryUrl('this adapter fails to generate temporary URL.', $path);
+            }
+        };
+
+        $filesystem = new Filesystem(
+            new FailoverAdapter(
+                'default',
+                $this->toInner([$adapter]),
+                new InMemoryMessageRepository()
+            )
+        );
+
+        $this->expectException(UnableToGenerateTemporaryUrl::class);
+
+        $filesystem->temporaryUrl('file.txt', new \DateTime('+1 day'));
+    }
+
+    /**
+     * @param list<FilesystemAdapter> $adapters
+     *
+     * @return list<InnerAdapter>
+     */
+    private function toInner(array $adapters): array
+    {
+        return array_map(fn (FilesystemAdapter $adapter) => new InnerAdapter($adapter), $adapters);
+    }
+}

--- a/tests/MessageHandler/ReplicateFileHandlerTest.php
+++ b/tests/MessageHandler/ReplicateFileHandlerTest.php
@@ -22,7 +22,7 @@ use Webf\FlysystemFailoverBundle\MessageRepository\InMemoryMessageRepository;
  *
  * @covers \Webf\FlysystemFailoverBundle\MessageHandler\ReplicateFileHandler
  */
-class ReplicateFileHandlerTest extends TestCase
+final class ReplicateFileHandlerTest extends TestCase
 {
     public function test_source_stream_can_be_non_seekable(): void
     {

--- a/tests/MessageRepository/DoctrineMessageRepositoryTest.php
+++ b/tests/MessageRepository/DoctrineMessageRepositoryTest.php
@@ -16,7 +16,7 @@ use Webf\FlysystemFailoverBundle\MessageRepository\MessageWithMetadata;
  *
  * @covers \Webf\FlysystemFailoverBundle\MessageRepository\DoctrineMessageRepository
  */
-class DoctrineMessageRepositoryTest extends TestCase
+final class DoctrineMessageRepositoryTest extends TestCase
 {
     public function test_push_then_pop(): void
     {

--- a/tests/MessageRepository/DoctrineMessageRepositoryTest.php
+++ b/tests/MessageRepository/DoctrineMessageRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Webf\FlysystemFailoverBundle\MessageRepository;
 
 use Doctrine\DBAL\DriverManager;

--- a/tests/MessageRepository/InMemoryMessageRepositoryTest.php
+++ b/tests/MessageRepository/InMemoryMessageRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Webf\FlysystemFailoverBundle\MessageRepository;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/MessageRepository/InMemoryMessageRepositoryTest.php
+++ b/tests/MessageRepository/InMemoryMessageRepositoryTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Webf\FlysystemFailoverBundle\MessageRepository;
+
+use PHPUnit\Framework\TestCase;
+use Webf\FlysystemFailoverBundle\Message\MessageInterface;
+use Webf\FlysystemFailoverBundle\MessageRepository\FindByCriteria;
+use Webf\FlysystemFailoverBundle\MessageRepository\FindResults;
+use Webf\FlysystemFailoverBundle\MessageRepository\InMemoryMessageRepository;
+use Webf\FlysystemFailoverBundle\MessageRepository\MessageWithMetadata;
+
+/**
+ * @internal
+ *
+ * @covers \Webf\FlysystemFailoverBundle\MessageRepository\InMemoryMessageRepository
+ */
+final class InMemoryMessageRepositoryTest extends TestCase
+{
+    public function test_messages_are_pushed_and_popped_in_the_right_order(): void
+    {
+        $repository = new InMemoryMessageRepository();
+
+        $repository->push($this->getFakeMessage('1'));
+        $repository->push($this->getFakeMessage('2'));
+        $repository->push($this->getFakeMessage('3'));
+        $repository->push($this->getFakeMessage('4'));
+        $repository->push($this->getFakeMessage('5'));
+
+        $this->assertEquals(['1', '2', '3', '4', '5'], $this->getAll($repository));
+        $this->assertEquals('1', (string) $repository->pop());
+        $this->assertEquals(['2', '3', '4', '5'], $this->getAll($repository));
+        $this->assertEquals('2', (string) $repository->pop());
+        $this->assertEquals(['3', '4', '5'], $this->getAll($repository));
+        $this->assertEquals(['3', '4', '5'], array_map(fn (MessageInterface $message) => (string) $message, $repository->popAll()));
+        $this->assertEquals([], $this->getAll($repository));
+        $this->assertEquals(null, $repository->pop());
+        $this->assertEquals([], $repository->popAll());
+    }
+
+    public function test_find_by_with_page_and_limit_criteria(): void
+    {
+        $repository = new InMemoryMessageRepository();
+
+        $repository->push($this->getFakeMessage('1'));
+        $repository->push($this->getFakeMessage('2'));
+        $repository->push($this->getFakeMessage('3'));
+        $repository->push($this->getFakeMessage('4'));
+        $repository->push($this->getFakeMessage('5'));
+
+        $this->assertEquals(
+            ['1', '2', '3'],
+            $this->getMessages($repository->findBy((new FindByCriteria())->setLimit(3)))
+        );
+
+        $this->assertEquals(
+            ['4', '5'],
+            $this->getMessages($repository->findBy((new FindByCriteria())->setLimit(3)->setPage(2)))
+        );
+
+        $this->assertEquals(
+            [],
+            $this->getMessages($repository->findBy((new FindByCriteria())->setLimit(3)->setPage(3)))
+        );
+
+        $this->assertEquals(
+            ['3', '4'],
+            $this->getMessages($repository->findBy((new FindByCriteria())->setLimit(2)->setPage(2)))
+        );
+
+        $this->assertEquals(
+            ['5'],
+            $this->getMessages($repository->findBy((new FindByCriteria())->setLimit(2)->setPage(3)))
+        );
+    }
+
+    public function test_find_by_with_failover_adapter_criteria(): void
+    {
+        $repository = new InMemoryMessageRepository();
+
+        $repository->push($this->getFakeMessage('1', 'a'));
+        $repository->push($this->getFakeMessage('2', 'b'));
+        $repository->push($this->getFakeMessage('3', 'a'));
+        $repository->push($this->getFakeMessage('4', 'b'));
+        $repository->push($this->getFakeMessage('5', 'a'));
+
+        $this->assertEquals(
+            ['1', '3', '5'],
+            $this->getMessages($repository->findBy((new FindByCriteria())->setFailoverAdapter('a')))
+        );
+
+        $this->assertEquals(
+            ['2', '4'],
+            $this->getMessages($repository->findBy((new FindByCriteria())->setFailoverAdapter('b')))
+        );
+
+        $this->assertEquals(
+            [],
+            $this->getMessages($repository->findBy((new FindByCriteria())->setFailoverAdapter('c')))
+        );
+
+        $this->assertEquals(
+            ['1', '3'],
+            $this->getMessages($repository->findBy((new FindByCriteria())->setFailoverAdapter('a')->setLimit(2)))
+        );
+
+        $this->assertEquals(
+            ['5'],
+            $this->getMessages($repository->findBy((new FindByCriteria())->setFailoverAdapter('a')->setLimit(2)->setPage(2)))
+        );
+    }
+
+    private function getFakeMessage(string $number, string $failoverAdapter = 'default'): MessageInterface
+    {
+        return new class($number, $failoverAdapter) implements MessageInterface {
+            public function __construct(
+                private readonly string $number,
+                private readonly string $failoverAdapter,
+            ) {
+            }
+
+            #[\Override]
+            public function getFailoverAdapter(): string
+            {
+                return $this->failoverAdapter;
+            }
+
+            #[\Override]
+            public function getPath(): string
+            {
+                throw new \LogicException('Not implemented');
+            }
+
+            #[\Override]
+            public function getInnerSourceAdapter(): ?int
+            {
+                throw new \LogicException('Not implemented');
+            }
+
+            #[\Override]
+            public function getInnerDestinationAdapter(): int
+            {
+                throw new \LogicException('Not implemented');
+            }
+
+            #[\Override]
+            public function getRetryCount(): int
+            {
+                throw new \LogicException('Not implemented');
+            }
+
+            #[\Override]
+            public function __toString()
+            {
+                return $this->number;
+            }
+        };
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getMessages(FindResults $results): array
+    {
+        return array_map(
+            fn (MessageWithMetadata $message) => (string) $message->getMessage(),
+            iterator_to_array($results->getItems())
+        );
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getAll(InMemoryMessageRepository $repository): array
+    {
+        return $this->getMessages($repository->findBy(new FindByCriteria()));
+    }
+}

--- a/tests/Service/SyncServiceTest.php
+++ b/tests/Service/SyncServiceTest.php
@@ -21,7 +21,7 @@ use Webf\FlysystemFailoverBundle\Service\SyncService;
  *
  * @covers \Webf\FlysystemFailoverBundle\Service\SyncService
  */
-class SyncServiceTest extends TestCase
+final class SyncServiceTest extends TestCase
 {
     public function test_missing_files_in_secondary_storages_are_replicated_from_first_storage(): void
     {

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.65"
+        "friendsofphp/php-cs-fixer": "^3.86"
     },
     "config": {
         "bin-dir": "../../bin"


### PR DESCRIPTION
Implements `ChecksumProvider`, `PublicUrlGenerator` and `TemporaryUrlGenerator` so that methods `checksum`, `publicUrl` and `temporaryUrl` of `League\Flysystem\Filesystem` can reach the first compatible inner adapter.