### PR TITLE
Fix altering db

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,8 @@
 name: test
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  push: ~
+  pull_request: ~
 
 jobs:
   psalm:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.composer/cache
@@ -65,7 +65,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.composer/cache
@@ -105,7 +105,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.composer/cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.6.1 (unreleased)
+
+### 🐛 Bug fixes
+
+* Fix dropping the rest of the database when creating the message table
+
 ## v0.6.0 (February 15, 2025)
 
 ### 💥 Breaking changes

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,6 +16,12 @@
         </ignoreFiles>
     </projectFiles>
 
+    <issueHandlers>
+        <ClassMustBeFinal errorLevel="suppress" />
+        <DeprecatedMethod errorLevel="suppress" />
+        <MissingOverrideAttribute errorLevel="suppress" />
+    </issueHandlers>
+
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin" />
     </plugins>

--- a/src/MessageRepository/DoctrineMessageRepository.php
+++ b/src/MessageRepository/DoctrineMessageRepository.php
@@ -302,19 +302,10 @@ class DoctrineMessageRepository implements MessageRepositoryInterface
     {
         $schemaManager = $this->connection->createSchemaManager();
 
-        $schema = new Schema(schemaConfig: $schemaManager->createSchemaConfig());
+        $schema = $schemaManager->introspectSchema();
         $this->addTableToSchema($schema);
 
-        $schemaManager->migrateSchema($this->getSchema());
-    }
-
-    private function getSchema(): Schema
-    {
-        $schemaManager = $this->connection->createSchemaManager();
-        $schema = new Schema([], [], $schemaManager->createSchemaConfig());
-        $this->addTableToSchema($schema);
-
-        return $schema;
+        $schemaManager->migrateSchema($schema);
     }
 
     private function addTableToSchema(Schema $schema): void

--- a/tests/MessageRepository/DoctrineMessageRepositoryTest.php
+++ b/tests/MessageRepository/DoctrineMessageRepositoryTest.php
@@ -56,6 +56,18 @@ class DoctrineMessageRepositoryTest extends TestCase
         $this->assertNull($repository->pop());
     }
 
+    public function test_push_creates_table_without_altering_the_rest_of_the_database(): void
+    {
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $connection->executeStatement('CREATE TABLE other_table (id INTEGER PRIMARY KEY AUTOINCREMENT)');
+        $connection->executeStatement('INSERT INTO other_table (id) VALUES (1)');
+        $repository = new DoctrineMessageRepository($connection, ['table_name' => 'adapter_messages']);
+
+        $this->assertEquals([['id' => 1]], $connection->executeQuery('SELECT * FROM other_table')->fetchAllAssociative());
+        $repository->push(new ReplicateFile('adapter', 'path1', 0, 1));
+        $this->assertEquals([['id' => 1]], $connection->executeQuery('SELECT * FROM other_table')->fetchAllAssociative());
+    }
+
     public function test_push_does_not_create_or_update_table_if_it_already_exists(): void
     {
         $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);


### PR DESCRIPTION
Critical bug fix : the full database was dropped if the message table didn't exist.

This bug is only present in v0.6.0, and only happen when a message is pushed to the Doctrine repository (i.e. calling Flysystem's `write*` or `delete*` methods) and the message table doesn't exist (i.e. it's the first time one of those methods are called in a project).

Technical details: the behavior of Doctrine's `AbstractSchemaManager` changed from v3 to v4, it now needs the full schema instead of a partial one containing only the table we want to create.